### PR TITLE
Change from Next Image tag to HTML img tag

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,6 @@ const nextConfig = {
     // Specify that we use the app-dir structure, not the page-dir structure
     experimental: {appDir: true},
 
-    // Next.js image optimization doesn't work with "output: 'export'"
-    images: {unoptimized: true},
-
     // Build as a static website
     output: 'export',
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,6 @@
 ﻿"use client";
 
 import styles from './navbar.module.css'
-import Image from 'next/image';
 import Link from 'next/link';
 import {FaBars, FaTimes} from "react-icons/fa";
 import {useState} from "react";
@@ -14,11 +13,11 @@ const Navbar = () => {
             className={`${dropdown ? styles.navbarContainerExtended : styles.navbarContainer} ${styles.limitHeightIfWide}`}>
             <div className={styles.navbarMenu}>
                 <Link href="/" className={styles.navbarLogo}>
-                    <Image src="/navbar-logo.webp"
-                           alt="Sylle Invest Logotype"
-                           width={150}
-                           height={64}
-                           priority={true}/>
+                    <img src="/navbar-logo.webp"
+                         alt="Sylle Invest Logotype"
+                         width="150"
+                         height="64"
+                    />
                 </Link>
 
                 <Link href="/about"


### PR DESCRIPTION
The HTML img tag replaces the Next Image tag because the latter one uses inline scripting, which the CSP-header style-src do not allow. Next Image was initially used for its image optimization, but now it can be removed as that feature does not work with static websites.